### PR TITLE
Change struct tag sep from  "," to "\n"

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Validators with parameters
 And here is small example of usage:
 ```go
 type Post struct {
-	Title    string `valid:"alphanum,required"`
-	Message  string `valid:"duck,ascii"`
+	Title    string `valid:"alphanum\nrequired"`
+	Message  string `valid:"duck\nascii"`
 	AuthorIP string `valid:"ipv4"`
 	Date     string `valid:"-"`
 }

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,8 @@ func Contains(str, substring string) bool {
 // Matches check if string matches the pattern (pattern is regular expression)
 // In case of error return false
 func Matches(str, pattern string) bool {
-	match, _ := regexp.MatchString(pattern, str)
+	regxp := regexp.MustCompile(pattern)
+	match := regxp.MatchString(str)
 	return match
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package govalidator
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -37,7 +38,6 @@ func TestMatches(t *testing.T) {
 		{"123456789", "[0-9]+", true},
 		{"abacada", "cab$", false},
 		{"111222333", "((111|222|333)+)+", true},
-		{"abacaba", "((123+]", false},
 	}
 	for _, test := range tests {
 		actual := Matches(test.param1, test.param2)
@@ -45,6 +45,27 @@ func TestMatches(t *testing.T) {
 			t.Errorf("Expected Matches(%q,%q) to be %v, got %v", test.param1, test.param2, test.expected, actual)
 		}
 	}
+}
+
+func TestMatchesPanic(t *testing.T) {
+	str := "abacaba"
+	rxp := "((123+]"
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Errorf("should have panicked but didn't (str: %#v  regexp: %#v)", str, rxp)
+		} else {
+			mtchd, err := regexp.MatchString("regexp.*Compile.*error parsing regexp", recovered.(string))
+			if err != nil {
+				t.Errorf("error creating regexp matcher to chec for error (TestMatchesPanic): %s", err.Error())
+			}
+			if !mtchd {
+				t.Errorf("panicked as expected for str:%#v and rxp:%#v, but with wrong panic message: %s", str, rxp, recovered)
+			}
+		}
+	}()
+	_ = Matches(str, rxp)
+	return
 }
 
 func TestLeftTrim(t *testing.T) {

--- a/validator.go
+++ b/validator.go
@@ -566,7 +566,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 // parseTag splits a struct field's tag into its
 // comma-separated options.
 func parseTag(tag string) tagOptions {
-	split := strings.SplitN(tag, ",", -1)
+	split := strings.SplitN(tag, "\n", -1)
 	return tagOptions(split)
 }
 
@@ -576,7 +576,7 @@ func isValidTag(s string) bool {
 	}
 	for _, c := range s {
 		switch {
-		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~, ", c):
 			// Backslash and quote chars are reserved, but
 			// otherwise any punctuation chars are allowed
 			// in a tag name.

--- a/validator_test.go
+++ b/validator_test.go
@@ -647,7 +647,7 @@ func TestIsRequestURL(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar#com", false},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -670,7 +670,7 @@ func TestIsRequestURL(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com#baz=qux", false},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},
@@ -697,7 +697,7 @@ func TestIsRequestURI(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar#com", false},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -719,7 +719,7 @@ func TestIsRequestURI(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com#baz=qux", false},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},
@@ -1784,16 +1784,16 @@ type Address struct {
 
 type User struct {
 	Name     string `valid:"required"`
-	Email    string `valid:"required,email"`
+	Email    string `valid:"required\nemail"`
 	Password string `valid:"required"`
-	Age      int    `valid:"required,numeric,@#\u0000"`
+	Age      int    `valid:"required\nnumeric,@#\u0000"`
 	Home     *Address
 	Work     []Address
 }
 
 type UserValid struct {
 	Name     string `valid:"required"`
-	Email    string `valid:"required,email"`
+	Email    string `valid:"required\nemail"`
 	Password string `valid:"required"`
 	Age      int    `valid:"required"`
 	Home     *Address
@@ -1828,7 +1828,7 @@ type StringMatchesStruct struct {
 }
 
 type Post struct {
-	Title    string `valid:"alpha,required"`
+	Title    string `valid:"alpha\nrequired"`
 	Message  string `valid:"ascii"`
 	AuthorIP string `valid:"ipv4"`
 }
@@ -1845,7 +1845,7 @@ type FieldsRequiredByDefaultButExemptStruct struct {
 
 type FieldsRequiredByDefaultButExemptOrOptionalStruct struct {
 	Name  string `valid:"-"`
-	Email string `valid:"optional,email"`
+	Email string `valid:"optional\nemail"`
 }
 
 type MessageWithSeveralFieldsStruct struct {


### PR DESCRIPTION
# commit d4be6e66ef140fa87de6bc604ba9438bf2eff599
Author: Gabriel Medina <gmedina@ooyala.com>
Date:   Fri Apr 29 20:29:09 2016 -0500

    Now invalid regular expressions for matches struct validator panic when they are malformed,
    added new test to check for panics on this use case.

# commit c2f9ddf074f7c04eabfcee58bd1d2b56c748d0cf
Author: Gabriel Medina <gmedina@ooyala.com>
Date:   Fri Apr 29 19:07:53 2016 -0500

    Changed: struct validation tag separator from "," to "\n".

    Using "," caused problems when used with expressions in regular expressions, accepting the input silently.
    Changing to "\n" allows for use of most characters (particularly one as uniquitous as the comma) without getting in the way of normally used expressions for validation.
